### PR TITLE
add local opam switch to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ ocsigen-i18n-rewriter
 ocsigen-i18n-generator
 ocsigen-i18n-checker
 i18n_generate.ml
+_opam/


### PR DESCRIPTION
Helps with development when using local switches for projects.