### PR TITLE
allow generation of secondary files

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,6 +12,7 @@ usage: ocsigen-i18n-generator [options] [< input] [> output]
   --input-file        TSV file containing keys and translations. If option is omited or set to -, read on stdin.
   --ouput-file        File TSV file containing keys and translations. If option is omitted or set to -, write on stdout.
   --external-type     Values passed to --languages option come from a predefined type (do not generate the type nor from/to string functions).
+  --primary           Generated file is secondary and depends on given primary file.
   -help               Display this list of options
   --help              Display this list of options
 ```

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name:         "ocsigen-i18n"
-version:      "3.6.0"
+version:      "3.7.0"
 synopsis:     "I18n made easy for web sites written with eliom"
 description:  "Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file"
 maintainer:   "Jan Rochel <jan@besport.com>"


### PR DESCRIPTION
When using multiple files, you end up with the problem that,
each file uses its own reference to keep track of which language is
used.

This new option allows the reusing of the same reference
accross all files.