### PR TITLE
Supporting Non-Eliom Projects

### DIFF
--- a/bin/ocsigen-i18n-generator
+++ b/bin/ocsigen-i18n-generator
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Execute ocsigen-i18n with the --eliom flag
+exec ocsigen-i18n --eliom "$@"
+

--- a/dune
+++ b/dune
@@ -15,7 +15,7 @@
 
 (executable
   (name i18n_generate)
-  (public_name ocsigen-i18n-generator)
+  (public_name ocsigen-i18n)
   (package ocsigen-i18n)
   (modules i18n_generate)
   (libraries str))
@@ -26,6 +26,10 @@
   (package ocsigen-i18n)
   (modules i18n_ppx_checker)
   (libraries str ppxlib))
+
+(install
+  (section bin)
+  (files bin/ocsigen-i18n-generator))
 
 (ocamllex i18n_generate)
 

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -417,7 +417,7 @@ let _ =
      | None -> failwith "abnormal") ;
      Format.fprintf output "\nend\n" ;
      Format.fprintf output "end\n" ;
-     Format.pp_print_string output "]\n") else
+     (* Format.pp_print_string output "]\n" *) ) else
      (
           if primary_module = None && not (!external_type) then
        ( print_type_eliom output ~variants

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -107,6 +107,7 @@ let print_type_eliom fmt ~variants =
     (Format.pp_print_list
        ~pp_sep:(fun fmt () -> Format.pp_print_string fmt "|")
        Format.pp_print_string) variants
+
 let print_type fmt ~variants =
   Format.fprintf fmt
     "type t = %a\n\
@@ -114,6 +115,7 @@ let print_type fmt ~variants =
     (Format.pp_print_list
        ~pp_sep:(fun fmt () -> Format.pp_print_string fmt "|")
        Format.pp_print_string) variants
+
 let print_header_eliom fmt ?primary_module ~default_language () =
   let server_language_reference =
     match primary_module with
@@ -156,7 +158,7 @@ let print_header fmt ?primary_module ~default_language () =
    let set_language language = \n\
    your_function_to_setting_language\n\
    \n\
-   let txt = Eliom_content.Html.F.txt \n\
+   let txt = txt \n\
 "
 
 (** Print the function [string_of_language] returning the string representation of a
@@ -395,13 +397,15 @@ let _ =
      let key_values = parse_lines variants [] lexbuf in
      let output = Format.formatter_of_out_channel out_chan in
      if (!file_part = "header") then 
-       ( print_type output ~variants
+       ( Format.fprintf output "open Tyxml.Html\n"
+       ; print_type output ~variants
        ; print_string_of_language output ~variants ~strings
        ; print_language_of_string output ~variants ~strings
        ; print_guess_language_of_string output ;
      print_list_of_languages output ~variants ;
      print_header output ?primary_module ~default_language () ) else if (!file_part = "body") then (
      (* Format.pp_print_string output "[%%shared\n" ; *)
+     Format.fprintf output "open Tyxml.Html\n";
      Format.fprintf output "module Tr = struct\n" ;
      (match primary_module with
      | Some pm -> print_module_body pm print_expr_html output key_values 

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -115,7 +115,7 @@ let print_type fmt ~variants =
       ~pp_sep:(fun fmt () -> Format.pp_print_string fmt "|")
       Format.pp_print_string) variants
 
-let print_header_eliom fmt ?primary_module ~default_language () =
+let print_generated_functions_eliom fmt ?primary_module ~default_language () =
   let server_language_reference =
     match primary_module with
     | None -> "Eliom_reference.Volatile.eref\n\
@@ -144,7 +144,7 @@ let print_header_eliom fmt ?primary_module ~default_language () =
   let%shared txt = Eliom_content.Html.F.txt\n\
   "
 
-let print_header fmt ?primary_module ~default_language () =
+let print_generated_functions fmt ?primary_module ~default_language () =
   let default_lang =
     match primary_module with
     | None -> "let default_language = " ^ default_language ^ "\n\ "
@@ -419,7 +419,7 @@ let _ =
          ; print_language_of_string_eliom output ~variants ~strings
          ; print_guess_language_of_string_eliom output
          ; print_list_of_languages_eliom output ~variants 
-         ; print_header_eliom output ?primary_module ~default_language ())
+         ; print_generated_functions_eliom output ?primary_module ~default_language ())
        else
          (Format.fprintf output "open Tyxml.Html\n"
          ; print_type output ~variants
@@ -427,7 +427,7 @@ let _ =
          ; print_language_of_string output ~variants ~strings
          ; print_guess_language_of_string output
          ; print_list_of_languages output ~variants
-         ; print_header output ?primary_module ~default_language ())
+         ; print_generated_functions output ?primary_module ~default_language ())
      
      )
      else ( 
@@ -446,7 +446,7 @@ let _ =
              ; print_language_of_string_eliom output ~variants ~strings
              ; print_guess_language_of_string_eliom output) ;
            print_list_of_languages_eliom output ~variants ;
-           print_header_eliom output ?primary_module ~default_language () ;
+           print_generated_functions_eliom output ?primary_module ~default_language () ;
            Format.pp_print_string output "[%%shared\n" ;
            Format.fprintf output "module Tr = struct\n" ;
            print_module_body_eliom print_expr_html output key_values ;
@@ -465,7 +465,7 @@ let _ =
              ; print_language_of_string output ~variants ~strings
              ; print_guess_language_of_string output
              ; print_list_of_languages output ~variants
-             ; print_header output ?primary_module ~default_language ()
+             ; print_generated_functions output ?primary_module ~default_language ()
              )
            else if not (primary_module = None) then
              ( match primary_module with

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -480,7 +480,7 @@ let _ =
      
 
    with Failure msg ->
-     failwith (Printf.sprintf "lined: %d"
+     failwith (Printf.sprintf "line: %d"
                  lexbuf.Lexing.lex_curr_p.Lexing.pos_lnum) ) ;
   close_out out_chan
 }

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -311,13 +311,13 @@ let _ =
   (try
      let key_values = parse_lines variants [] lexbuf in
      let output = Format.formatter_of_out_channel out_chan in
-     if primary_module = None && not (!external_type) then
+     if (!file_part = "header") then 
        ( print_type output ~variants
        ; print_string_of_language output ~variants ~strings
        ; print_language_of_string output ~variants ~strings
-       ; print_guess_language_of_string output) ;
+       ; print_guess_language_of_string output ;
      print_list_of_languages output ~variants ;
-     print_header output ?primary_module ~default_language () ;
+     print_header output ?primary_module ~default_language () ) else (
      Format.pp_print_string output "[%%shared\n" ;
      Format.fprintf output "module Tr = struct\n" ;
      print_module_body print_expr_html output key_values ;
@@ -325,7 +325,7 @@ let _ =
      print_module_body print_expr_string output key_values ;
      Format.fprintf output "\nend\n" ;
      Format.fprintf output "end\n" ;
-     Format.pp_print_string output "]\n"
+     Format.pp_print_string output "]\n")
    with Failure msg ->
      failwith (Printf.sprintf "line: %d"
                  lexbuf.Lexing.lex_curr_p.Lexing.pos_lnum) ) ;

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -425,7 +425,7 @@ let _ =
        ; print_language_of_string_eliom output ~variants ~strings
        ; print_guess_language_of_string_eliom output) ;
      print_list_of_languages_eliom output ~variants ;
-     print_header output ?primary_module ~default_language () ;
+     print_header_eliom output ?primary_module ~default_language () ;
      Format.pp_print_string output "[%%shared\n" ;
      Format.fprintf output "module Tr = struct\n" ;
      print_module_body_eliom print_expr_html output key_values ;

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -165,6 +165,8 @@ let print_generated_functions fmt ?primary_module ~default_language () =
    let txt = txt \n\
   "
 
+
+  
 (** Print the function [string_of_language] returning the string representation of a
     value o type t. The string representation is simply the value as a string. For
     example, the string representation of [Us] is ["Us"]
@@ -216,6 +218,21 @@ let print_guess_language_of_string_eliom =
 let print_guess_language_of_string =
   helper_print_guess_language_of_string ~eliom:false
 
+
+let print_header_eliom output variants strings =
+  print_type_eliom output ~variants
+  ; print_string_of_language_eliom output ~variants ~strings
+  ; print_language_of_string_eliom output ~variants ~strings
+  ; print_guess_language_of_string_eliom output
+
+let print_header output variants strings primary_module default_language =
+  Format.fprintf output "open Tyxml.Html\n"
+  ; print_type output ~variants
+  ; print_string_of_language output ~variants ~strings
+  ; print_language_of_string output ~variants ~strings
+  ; print_guess_language_of_string output
+  ; print_list_of_languages output ~variants
+  ; print_generated_functions output ?primary_module ~default_language ()
 
 type arg = M of string | O of string
 
@@ -414,19 +431,9 @@ let _ =
      let output = Format.formatter_of_out_channel out_chan in
      if !header then (
        if !eliom_generation then
-         (print_type_eliom output ~variants
-         ; print_string_of_language_eliom output ~variants ~strings
-         ; print_language_of_string_eliom output ~variants ~strings
-         ; print_guess_language_of_string_eliom output)
+         (print_header_eliom output variants strings)
        else
-         (Format.fprintf output "open Tyxml.Html\n"
-         ; print_type output ~variants
-         ; print_string_of_language output ~variants ~strings
-         ; print_language_of_string output ~variants ~strings
-         ; print_guess_language_of_string output
-         ; print_list_of_languages output ~variants
-         ; print_generated_functions output ?primary_module ~default_language ())
-     
+         (print_header output variants strings primary_module default_language)
      )
      else ( 
        let in_chan =
@@ -439,10 +446,7 @@ let _ =
        if !eliom_generation then 
          (  
            if primary_module = None && not (!external_type) then
-             ( print_type_eliom output ~variants
-             ; print_string_of_language_eliom output ~variants ~strings
-             ; print_language_of_string_eliom output ~variants ~strings
-             ; print_guess_language_of_string_eliom output) ;
+             ( print_header_eliom output variants strings) ;
            print_list_of_languages_eliom output ~variants ;
            print_generated_functions_eliom output ?primary_module ~default_language () ;
            Format.pp_print_string output "[%%shared\n" ;
@@ -457,14 +461,7 @@ let _ =
        else 
          (
            if primary_module = None && not (!external_type) then
-             (Format.fprintf output "open Tyxml.Html\n" 
-             ; print_type output ~variants
-             ; print_string_of_language output ~variants ~strings
-             ; print_language_of_string output ~variants ~strings
-             ; print_guess_language_of_string output
-             ; print_list_of_languages output ~variants
-             ; print_generated_functions output ?primary_module ~default_language ()
-             )
+             (print_header output variants strings primary_module default_language)
            else if not (primary_module = None) then
              ( match primary_module with
              | Some(module_name) -> Format.fprintf output "open %s \n" module_name 

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -418,9 +418,7 @@ let _ =
          ; print_type output ~variants
          ; print_string_of_language output ~variants ~strings
          ; print_language_of_string output ~variants ~strings
-         ; print_guess_language_of_string output 
-         ; print_list_of_languages output ~variants
-         ; print_header output ?primary_module ~default_language () )
+         ; print_guess_language_of_string output)
      )
      else ( 
        let in_chan =
@@ -454,10 +452,10 @@ let _ =
              ( print_type output ~variants
              ; print_string_of_language output ~variants ~strings
              ; print_language_of_string output ~variants ~strings
-             ; print_guess_language_of_string output 
-             ; print_list_of_languages output ~variants
-             ; print_header output ?primary_module ~default_language () )  ;
-           Format.fprintf output "module Tr = struct\n" 
+             ; print_guess_language_of_string output)  ;
+             print_list_of_languages output ~variants
+           ; print_header output ?primary_module ~default_language ()
+           ; Format.fprintf output "module Tr = struct\n"
            ; print_module_body primary_module print_expr_html output key_values 
            ; Format.fprintf output "\nmodule S = struct\n" 
            ; print_module_body primary_module print_expr_string output key_values

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -417,9 +417,7 @@ let _ =
          (print_type_eliom output ~variants
          ; print_string_of_language_eliom output ~variants ~strings
          ; print_language_of_string_eliom output ~variants ~strings
-         ; print_guess_language_of_string_eliom output
-         ; print_list_of_languages_eliom output ~variants 
-         ; print_generated_functions_eliom output ?primary_module ~default_language ())
+         ; print_guess_language_of_string_eliom output)
        else
          (Format.fprintf output "open Tyxml.Html\n"
          ; print_type output ~variants

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -408,12 +408,11 @@ let _ =
      Format.fprintf output "module Tr = struct\n" ;
      (match primary_module with
      | Some pm -> print_module_body pm print_expr_html output key_values 
-     | None -> failwith "abnormal") ;
-     print_string "error ? 2\n" ;
+     | None -> failwith "Error: no primary module for the body") ;
      Format.fprintf output "\nmodule S = struct\n" ;
      (match primary_module with
      | Some pm -> print_module_body pm print_expr_string output key_values
-     | None -> failwith "abnormal")    ;
+     | None -> failwith "Error: no primary module for the body")    ;
      Format.fprintf output "\nend\n" ;
      Format.fprintf output "end\n")
      else

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -162,7 +162,6 @@ let print_generated_functions fmt ?primary_module ~default_language () =
    let set_language language = \n\
    your_function_to_setting_language\n\
    \n\
-   let txt = txt \n\
   "
 
 

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -244,7 +244,7 @@ let languages = ref ""
 let default_language = ref ""
 let external_type = ref false
 let primary_file = ref ""
-
+let file_part = ref ""
 let options = Arg.align
     [ ( "--languages", Arg.Set_string languages
       , " Comma-separated languages (e.g. en,fr-fr, or Foo.Fr,Foo.Us if \
@@ -263,6 +263,8 @@ let options = Arg.align
          (do not generate the type nor from/to string functions).")
     ; ( "--primary", Arg.Set_string primary_file
       , " Generated file is secondary and depends on given primary file.")
+    ; ( "--file-part", Arg.Set_string file_part
+      , " Part of the file that's generated (header or body).")
     ]
 
 let usage = "usage: ocsigen-i18n-generator [options] [< input] [> output]"

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -448,7 +448,10 @@ let _ =
      let output = Format.formatter_of_out_channel out_chan in
      if !header then (
        if !eliom_generation then
-         (print_header_eliom output variants strings)
+         (print_header_eliom output variants strings ;
+          print_list_of_languages_eliom output ~variants ;
+          print_generated_functions_eliom output ?primary_module ~default_language () 
+         )
        else
          (print_header output variants strings primary_module default_language)
      )
@@ -463,8 +466,8 @@ let _ =
        if !eliom_generation then 
          (if primary_module = None && not (!external_type) then
             (print_header_eliom output variants strings) ;
-             print_list_of_languages_eliom output ~variants ;
-             print_generated_functions_eliom output ?primary_module ~default_language () ;
+          print_list_of_languages_eliom output ~variants ;
+          print_generated_functions_eliom output ?primary_module ~default_language () ;
           print_body_eliom output key_values)
        else 
          (if primary_module = None && not (!external_type) then

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -220,19 +220,19 @@ let print_guess_language_of_string =
 
 
 let print_header_eliom output variants strings =
-  print_type_eliom output ~variants
-  ; print_string_of_language_eliom output ~variants ~strings
-  ; print_language_of_string_eliom output ~variants ~strings
-  ; print_guess_language_of_string_eliom output
+  print_type_eliom output ~variants ;
+  print_string_of_language_eliom output ~variants ~strings ;
+  print_language_of_string_eliom output ~variants ~strings ;
+  print_guess_language_of_string_eliom output
 
 let print_header output variants strings primary_module default_language =
-  Format.fprintf output "open Tyxml.Html\n"
-  ; print_type output ~variants
-  ; print_string_of_language output ~variants ~strings
-  ; print_language_of_string output ~variants ~strings
-  ; print_guess_language_of_string output
-  ; print_list_of_languages output ~variants
-  ; print_generated_functions output ?primary_module ~default_language ()
+  Format.fprintf output "open Tyxml.Html\n" ;
+  print_type output ~variants ;
+  print_string_of_language output ~variants ~strings ;
+  print_language_of_string output ~variants ~strings ;
+  print_guess_language_of_string output ;
+  print_list_of_languages output ~variants ;
+  print_generated_functions output ?primary_module ~default_language ()
 
 type arg = M of string | O of string
 
@@ -310,8 +310,7 @@ let print_module_body primary_module print_expr =
                ~pp_sep:(fun fmt () -> Format.pp_print_string fmt "\n")
                (fun fmt (language, tr) ->
                   Format.fprintf fmt "| %s -> %a"
-                    language print_expr tr) ) tr )
-    )
+                    language print_expr tr) ) tr ))
 
 let pp_print_list fmt printer =
   Format.fprintf fmt "[%a]"
@@ -368,13 +367,15 @@ let print_body_eliom output key_values =
   Format.fprintf output "\nend\n" ;
   Format.fprintf output "end\n" ;
   Format.pp_print_string output "]\n"
+
 let print_body output key_values primary_module =
-  Format.fprintf output "module Tr = struct\n"
-  ; print_module_body primary_module print_expr_html output key_values 
-  ; Format.fprintf output "\nmodule S = struct\n" 
-  ; print_module_body primary_module print_expr_string output key_values
-  ; Format.fprintf output "\nend\n" 
-  ; Format.fprintf output "end\n"
+  Format.fprintf output "module Tr = struct\n" ;
+  print_module_body primary_module print_expr_html output key_values ;
+  Format.fprintf output "\nmodule S = struct\n" ;
+  print_module_body primary_module print_expr_string output key_values ;
+  Format.fprintf output "\nend\n" ;
+  Format.fprintf output "end\n"
+
 let input_file = ref "-"
 let output_file = ref "-"
 let eliom_generation = ref false
@@ -460,27 +461,21 @@ let _ =
        try
        let key_values = parse_lines variants [] lexbuf in
        if !eliom_generation then 
-         (  
-           if primary_module = None && not (!external_type) then
-             ( print_header_eliom output variants strings) ;
-           print_list_of_languages_eliom output ~variants ;
-           print_generated_functions_eliom output ?primary_module ~default_language () ;
-
-           print_body_eliom output key_values
-         )
+         (if primary_module = None && not (!external_type) then
+            (print_header_eliom output variants strings) ;
+             print_list_of_languages_eliom output ~variants ;
+             print_generated_functions_eliom output ?primary_module ~default_language () ;
+          print_body_eliom output key_values)
        else 
-         (
-           if primary_module = None && not (!external_type) then
-             (print_header output variants strings primary_module default_language)
-           else if not (primary_module = None) then
-             ( match primary_module with
-             | Some(module_name) -> Format.fprintf output "open %s \n" module_name 
-             | None -> failwith "Not possible"
-             ) ;
-           print_body output key_values primary_module
-         )
-
-     ; close_in in_chan 
+         (if primary_module = None && not (!external_type) then
+            (print_header output variants strings primary_module default_language)
+          else if not (primary_module = None) then
+            (match primary_module with
+            | Some(module_name) -> Format.fprintf output "open %s \n" module_name 
+            | None -> failwith "Not possible"
+            ) ;
+           print_body output key_values primary_module) ;
+     close_in in_chan 
      
 
    with Failure msg ->

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -30,7 +30,6 @@ let flush buffer acc =
     | x -> Str x :: acc in
   Buffer.clear buffer
 ; acc
-
 }
 
 let lower = ['a'-'z']
@@ -403,9 +402,9 @@ let _ =
        ; print_language_of_string output ~variants ~strings
        ; print_guess_language_of_string output ;
      print_list_of_languages output ~variants ;
-     print_header output ?primary_module ~default_language () ) else if (!file_part = "body") then (
-     (* Format.pp_print_string output "[%%shared\n" ; *)
-     Format.fprintf output "open Tyxml.Html\n";
+         print_header output ?primary_module ~default_language () )
+     else if (!file_part = "body") then 
+     (Format.fprintf output "open Tyxml.Html\n";
      Format.fprintf output "module Tr = struct\n" ;
      (match primary_module with
      | Some pm -> print_module_body pm print_expr_html output key_values 
@@ -414,12 +413,11 @@ let _ =
      Format.fprintf output "\nmodule S = struct\n" ;
      (match primary_module with
      | Some pm -> print_module_body pm print_expr_string output key_values
-     | None -> failwith "abnormal") ;
+     | None -> failwith "abnormal")    ;
      Format.fprintf output "\nend\n" ;
-     Format.fprintf output "end\n" ;
-     (* Format.pp_print_string output "]\n" *) ) else
-     (
-          if primary_module = None && not (!external_type) then
+     Format.fprintf output "end\n")
+     else
+     (if primary_module = None && not (!external_type) then
        ( print_type_eliom output ~variants
        ; print_string_of_language_eliom output ~variants ~strings
        ; print_language_of_string_eliom output ~variants ~strings

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -38,59 +38,59 @@ let num = ['0'-'9']
 
 let id = (lower | ['_']) (lower | upper | num | ['_'])*
 
-rule parse_lines langs acc = parse
-  | (id as key) '\t' {
-      (* FIXME: Will break if List.map change its order of execution *)
-      let tr = List.map (fun lang ->
-          (lang, parse_expr (Buffer.create 0) [] lexbuf) ) langs in
-    eol langs ((key, tr) :: acc) lexbuf }
-  | eof { List.rev acc }
+         rule parse_lines langs acc = parse
+           | (id as key) '\t' {
+               (* FIXME: Will break if List.map change its order of execution *)
+               let tr = List.map (fun lang ->
+                   (lang, parse_expr (Buffer.create 0) [] lexbuf) ) langs in
+               eol langs ((key, tr) :: acc) lexbuf }
+           | eof { List.rev acc }
 
-and eol langs acc = parse
-  | [^'\n']* "\n" { Lexing.new_line lexbuf
-                  ; parse_lines langs acc lexbuf}
-  | eof { List.rev acc }
+         and eol langs acc = parse
+           | [^'\n']* "\n" { Lexing.new_line lexbuf
+                           ; parse_lines langs acc lexbuf}
+           | eof { List.rev acc }
 
-and parse_expr buffer acc = parse
+         and parse_expr buffer acc = parse
 
-  | "{{{" ' '* (id as c) ' '* "?" {
-    let s1 = parse_string_1 (Buffer.create 0) lexbuf in
-    let s2 = parse_string_2 (Buffer.create 0) lexbuf in
-    let acc = flush buffer acc in
-    parse_expr buffer (Cond (c, s1, s2) :: acc) lexbuf
-  }
+           | "{{{" ' '* (id as c) ' '* "?" {
+               let s1 = parse_string_1 (Buffer.create 0) lexbuf in
+               let s2 = parse_string_2 (Buffer.create 0) lexbuf in
+               let acc = flush buffer acc in
+               parse_expr buffer (Cond (c, s1, s2) :: acc) lexbuf
+             }
 
-  | "{{" ' '* (id as x) ' '* "}}" {
-      let acc = flush buffer acc in
-      parse_expr buffer (Var x :: acc) lexbuf }
+           | "{{" ' '* (id as x) ' '* "}}" {
+               let acc = flush buffer acc in
+               parse_expr buffer (Var x :: acc) lexbuf }
 
-  | "{{" ' '* (id as x) ' '* ('%' [^ ' ' '}']+ as f)  ' '* "}}" {
-      let acc = flush buffer acc in
-      parse_expr buffer (Var_typed (x, f) :: acc) lexbuf }
+           | "{{" ' '* (id as x) ' '* ('%' [^ ' ' '}']+ as f)  ' '* "}}" {
+               let acc = flush buffer acc in
+               parse_expr buffer (Var_typed (x, f) :: acc) lexbuf }
 
-  | '\t' | "" { List.rev (flush buffer acc ) }
+           | '\t' | "" { List.rev (flush buffer acc ) }
 
-  | [^ '\n' '\t'] as c { Buffer.add_char buffer c
-                       ; parse_expr buffer acc lexbuf }
+           | [^ '\n' '\t'] as c { Buffer.add_char buffer c
+                                ; parse_expr buffer acc lexbuf }
 
-and parse_string_1 buffer = parse
-  | "||" { String.escaped (Buffer.contents buffer) }
-  | _ as c { Buffer.add_char buffer c
-           ; parse_string_1 buffer lexbuf }
+         and parse_string_1 buffer = parse
+           | "||" { String.escaped (Buffer.contents buffer) }
+           | _ as c { Buffer.add_char buffer c
+                    ; parse_string_1 buffer lexbuf }
 
-and parse_string_2 buffer = parse
-  | "}}}" { String.escaped (Buffer.contents buffer) }
-  | _ as c { Buffer.add_char buffer c
-           ; parse_string_2 buffer lexbuf }
+         and parse_string_2 buffer = parse
+           | "}}}" { String.escaped (Buffer.contents buffer) }
+           | _ as c { Buffer.add_char buffer c
+                    ; parse_string_2 buffer lexbuf }
 
-{
+             {
 
-let print_list_of_languages_eliom fmt ~variants =
-  Format.fprintf fmt
-    "let%%shared languages = [%a]\n"
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ";")
-       Format.pp_print_string) variants
+               let print_list_of_languages_eliom fmt ~variants =
+                 Format.fprintf fmt
+                   "let%%shared languages = [%a]\n"
+                   (Format.pp_print_list
+                      ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ";")
+                      Format.pp_print_string) variants
 
 let print_list_of_languages fmt ~variants =
   Format.fprintf fmt
@@ -132,17 +132,17 @@ let print_header_eliom fmt ?primary_module ~default_language () =
   in
   Format.pp_print_string fmt @@
   default_lang ^
-   "let%server _language_ = " ^ server_language_reference ^ "\n\
-   let%server get_language () = Eliom_reference.Volatile.get _language_\n\
-   let%server set_language language = \n\
-   Eliom_reference.Volatile.set _language_ language\n\
-   \n\
-   let%client _language_ = " ^ client_language_reference ^ "\n\
-   let%client get_language () = !_language_\n\
-   let%client set_language language = _language_ := language\n\
-   \n\
-   let%shared txt = Eliom_content.Html.F.txt\n\
-"
+  "let%server _language_ = " ^ server_language_reference ^ "\n\
+                                                            let%server get_language () = Eliom_reference.Volatile.get _language_\n\
+                                                            let%server set_language language = \n\
+                                                            Eliom_reference.Volatile.set _language_ language\n\
+                                                            \n\
+                                                            let%client _language_ = " ^ client_language_reference ^ "\n\
+                                                                                                                     let%client get_language () = !_language_\n\
+                                                                                                                     let%client set_language language = _language_ := language\n\
+                                                                                                                     \n\
+                                                                                                                     let%shared txt = Eliom_content.Html.F.txt\n\
+                                                                                                                    "
 
 let print_header fmt ?primary_module ~default_language () =
   let  default_lang =
@@ -152,13 +152,13 @@ let print_header fmt ?primary_module ~default_language () =
   in
   Format.pp_print_string fmt @@
   default_lang ^
-   "let _language_ = default_language \n\
+  "let _language_ = default_language \n\
    let get_language () = your_function_to_getting_language \n\
    let set_language language = \n\
    your_function_to_setting_language\n\
    \n\
    let txt = txt \n\
-"
+  "
 
 (** Print the function [string_of_language] returning the string representation of a
     value o type t. The string representation is simply the value as a string. For
@@ -265,16 +265,29 @@ let print_module_body primary_module print_expr =
     ~pp_sep:(fun fmt () -> Format.pp_print_string fmt "\n")
     (fun fmt (key, tr) ->
        let args = args (List.map snd tr) in
-       Format.fprintf fmt "let %s ?(lang = %s.get_language ()) () %a () =\n\
-                           match lang with\n%a"
-         key
-         primary_module
-         print_args args
-         (Format.pp_print_list
-            ~pp_sep:(fun fmt () -> Format.pp_print_string fmt "\n")
-            (fun fmt (language, tr) ->
-               Format.fprintf fmt "| %s -> %a"
-                 language print_expr tr) ) tr )
+       match primary_module with
+       | Some pm -> 
+         (Format.fprintf fmt "let %s ?(lang = %s.get_language ()) () %a () =\n\
+                              match lang with\n%a"
+            key
+            pm
+            print_args args
+            (Format.pp_print_list
+               ~pp_sep:(fun fmt () -> Format.pp_print_string fmt "\n")
+               (fun fmt (language, tr) ->
+                  Format.fprintf fmt "| %s -> %a"
+                    language print_expr tr) ) tr )
+       | None -> 
+         (Format.fprintf fmt "let %s ?(lang = get_language ()) () %a () =\n\
+                              match lang with\n%a"
+            key
+            print_args args
+            (Format.pp_print_list
+               ~pp_sep:(fun fmt () -> Format.pp_print_string fmt "\n")
+               (fun fmt (language, tr) ->
+                  Format.fprintf fmt "| %s -> %a"
+                    language print_expr tr) ) tr )
+    )
 
 let pp_print_list fmt printer =
   Format.fprintf fmt "[%a]"
@@ -285,22 +298,22 @@ let pp_print_list fmt printer =
 let print_expr_html fmt key_values =
   let print_key_value fmt =
     function
-       | Str s -> Format.fprintf fmt "[txt \"%s\"]" s
-       | Var v -> Format.pp_print_string fmt v
-       | Var_typed (v, f) ->
-         Format.fprintf fmt "[txt (Printf.sprintf \"%s\" %s)]" f v
-       | Cond (c, s1, s2) ->
-         Format.fprintf fmt "[txt (if %s then \"%s\" else \"%s\")]"
-           c s1 s2
+    | Str s -> Format.fprintf fmt "[txt \"%s\"]" s
+    | Var v -> Format.pp_print_string fmt v
+    | Var_typed (v, f) ->
+      Format.fprintf fmt "[txt (Printf.sprintf \"%s\" %s)]" f v
+    | Cond (c, s1, s2) ->
+      Format.fprintf fmt "[txt (if %s then \"%s\" else \"%s\")]"
+        c s1 s2
   in
   match key_values with
   | [] ->
-     assert false
+    assert false
   | [key_value] ->
-     print_key_value fmt key_value
+    print_key_value fmt key_value
   | _ ->
-     Format.fprintf fmt "List.flatten " ;
-     pp_print_list fmt print_key_value key_values
+    Format.fprintf fmt "List.flatten " ;
+    pp_print_list fmt print_key_value key_values
 
 let print_expr_string fmt key_values =
   let print_key_value fmt =
@@ -308,27 +321,28 @@ let print_expr_string fmt key_values =
     | Str s -> Format.fprintf fmt "\"%s\"" s
     | Var v -> Format.pp_print_string fmt v
     | Var_typed (v, f) ->
-       Format.fprintf fmt "(Printf.sprintf \"%s\" %s)" f v
+      Format.fprintf fmt "(Printf.sprintf \"%s\" %s)" f v
     | Cond (c, s1, s2) ->
-       Format.fprintf fmt "(if %s then \"%s\" else \"%s\")"
-         c s1 s2
-    in
-    match key_values with
-    | [] ->
-       assert false
-    | [key_value] ->
-       print_key_value fmt key_value
-    | _ ->
-       Format.fprintf fmt "String.concat \"\" " ;
-       pp_print_list fmt print_key_value key_values
+      Format.fprintf fmt "(if %s then \"%s\" else \"%s\")"
+        c s1 s2
+  in
+  match key_values with
+  | [] ->
+    assert false
+  | [key_value] ->
+    print_key_value fmt key_value
+  | _ ->
+    Format.fprintf fmt "String.concat \"\" " ;
+    pp_print_list fmt print_key_value key_values
 
 let input_file = ref "-"
 let output_file = ref "-"
+let eliom_generation = ref false
+let header = ref false
 let languages = ref ""
 let default_language = ref ""
 let external_type = ref false
 let primary_file = ref ""
-let file_part = ref ""
 let options = Arg.align
     [ ( "--languages", Arg.Set_string languages
       , " Comma-separated languages (e.g. en,fr-fr, or Foo.Fr,Foo.Us if \
@@ -347,8 +361,10 @@ let options = Arg.align
          (do not generate the type nor from/to string functions).")
     ; ( "--primary", Arg.Set_string primary_file
       , " Generated file is secondary and depends on given primary file.")
-    ; ( "--file-part", Arg.Set_string file_part
-      , " Part of the file that's generated (header or body).")
+    ; ( "--eliom", Arg.Set eliom_generation
+      , " File-generation for eliom.")
+    ; ( "--header", Arg.Set header
+      , " Generate only the header file.")
     ]
 
 let usage = "usage: ocsigen-i18n-generator [options] [< input] [> output]"
@@ -357,9 +373,9 @@ let _ = Arg.parse options (fun s -> ()) usage
 
 let normalize_type ?primary_module s =
   let constr =
-  String.lowercase_ascii s
-  |> Str.(global_replace (regexp "-") "_")
-  |> String.capitalize_ascii
+    String.lowercase_ascii s
+    |> Str.(global_replace (regexp "-") "_")
+    |> String.capitalize_ascii
   in
   match primary_module with
   | None -> constr
@@ -375,9 +391,9 @@ let _ =
     | "-" -> stdout
     | file -> open_out file in
   let primary_module = match !primary_file with
-  | "" -> None
-  | file -> let base = Filename.remove_extension file in
-            Some (String.capitalize_ascii base)
+    | "" -> None
+    | file -> let base = Filename.remove_extension file in
+      Some (String.capitalize_ascii base)
   in
   let strings = Str.split (Str.regexp ",") !languages in
   let variants =
@@ -395,43 +411,61 @@ let _ =
   (try
      let key_values = parse_lines variants [] lexbuf in
      let output = Format.formatter_of_out_channel out_chan in
-     if (!file_part = "header") then 
-       ( Format.fprintf output "open Tyxml.Html\n"
-       ; print_type output ~variants
-       ; print_string_of_language output ~variants ~strings
-       ; print_language_of_string output ~variants ~strings
-       ; print_guess_language_of_string output ;
-     print_list_of_languages output ~variants ;
-         print_header output ?primary_module ~default_language () )
-     else if (!file_part = "body") then 
-     (Format.fprintf output "open Tyxml.Html\n";
-     Format.fprintf output "module Tr = struct\n" ;
-     (match primary_module with
-     | Some pm -> print_module_body pm print_expr_html output key_values 
-     | None -> failwith "Error: no primary module for the body") ;
-     Format.fprintf output "\nmodule S = struct\n" ;
-     (match primary_module with
-     | Some pm -> print_module_body pm print_expr_string output key_values
-     | None -> failwith "Error: no primary module for the body")    ;
-     Format.fprintf output "\nend\n" ;
-     Format.fprintf output "end\n")
-     else
-     (if primary_module = None && not (!external_type) then
-       ( print_type_eliom output ~variants
-       ; print_string_of_language_eliom output ~variants ~strings
-       ; print_language_of_string_eliom output ~variants ~strings
-       ; print_guess_language_of_string_eliom output) ;
-     print_list_of_languages_eliom output ~variants ;
-     print_header_eliom output ?primary_module ~default_language () ;
-     Format.pp_print_string output "[%%shared\n" ;
-     Format.fprintf output "module Tr = struct\n" ;
-     print_module_body_eliom print_expr_html output key_values ;
-     Format.fprintf output "\nmodule S = struct\n" ;
-     print_module_body_eliom print_expr_string output key_values ;
-     Format.fprintf output "\nend\n" ;
-     Format.fprintf output "end\n" ;
-     Format.pp_print_string output "]\n"
-     )
+     if (!eliom_generation) then 
+       ( if !header then
+           (print_type_eliom output ~variants
+           ; print_string_of_language_eliom output ~variants ~strings
+           ; print_language_of_string_eliom output ~variants ~strings
+           ; print_guess_language_of_string_eliom output)
+         else 
+
+         if primary_module = None && not (!external_type) then
+           ( print_type_eliom output ~variants
+           ; print_string_of_language_eliom output ~variants ~strings
+           ; print_language_of_string_eliom output ~variants ~strings
+           ; print_guess_language_of_string_eliom output) ;
+         print_list_of_languages_eliom output ~variants ;
+         print_header_eliom output ?primary_module ~default_language () ;
+         Format.pp_print_string output "[%%shared\n" ;
+         Format.fprintf output "module Tr = struct\n" ;
+         print_module_body_eliom print_expr_html output key_values ;
+         Format.fprintf output "\nmodule S = struct\n" ;
+         print_module_body_eliom print_expr_string output key_values ;
+         Format.fprintf output "\nend\n" ;
+         Format.fprintf output "end\n" ;
+         Format.pp_print_string output "]\n"
+       )
+     else 
+       ( if !header then
+           (Format.fprintf output "open Tyxml.Html\n"
+           ; print_type output ~variants
+           ; print_string_of_language output ~variants ~strings
+           ; print_language_of_string output ~variants ~strings
+           ; print_guess_language_of_string output 
+           ; print_list_of_languages output ~variants
+           ; print_header output ?primary_module ~default_language () )
+         else 
+           (
+             Format.fprintf output "open Tyxml.Html\n" ;
+
+             if primary_module = None && not (!external_type) then
+
+               ( print_type output ~variants
+               ; print_string_of_language output ~variants ~strings
+               ; print_language_of_string output ~variants ~strings
+               ; print_guess_language_of_string output 
+               ; print_list_of_languages output ~variants
+               ; print_header output ?primary_module ~default_language () )  ;
+
+
+             Format.fprintf output "module Tr = struct\n" 
+             ; print_module_body primary_module print_expr_html output key_values 
+             ; Format.fprintf output "\nmodule S = struct\n" 
+             ; print_module_body primary_module print_expr_string output key_values
+             ; Format.fprintf output "\nend\n" 
+             ; Format.fprintf output "end\n")
+       )
+
    with Failure msg ->
      failwith (Printf.sprintf "lined: %d"
                  lexbuf.Lexing.lex_curr_p.Lexing.pos_lnum) ) ;

--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -359,6 +359,22 @@ let print_expr_string fmt key_values =
     Format.fprintf fmt "String.concat \"\" " ;
     pp_print_list fmt print_key_value key_values
 
+let print_body_eliom output key_values = 
+  Format.pp_print_string output "[%%shared\n" ;
+  Format.fprintf output "module Tr = struct\n" ;
+  print_module_body_eliom print_expr_html output key_values ;
+  Format.fprintf output "\nmodule S = struct\n" ;
+  print_module_body_eliom print_expr_string output key_values ;
+  Format.fprintf output "\nend\n" ;
+  Format.fprintf output "end\n" ;
+  Format.pp_print_string output "]\n"
+let print_body output key_values primary_module =
+  Format.fprintf output "module Tr = struct\n"
+  ; print_module_body primary_module print_expr_html output key_values 
+  ; Format.fprintf output "\nmodule S = struct\n" 
+  ; print_module_body primary_module print_expr_string output key_values
+  ; Format.fprintf output "\nend\n" 
+  ; Format.fprintf output "end\n"
 let input_file = ref "-"
 let output_file = ref "-"
 let eliom_generation = ref false
@@ -449,14 +465,8 @@ let _ =
              ( print_header_eliom output variants strings) ;
            print_list_of_languages_eliom output ~variants ;
            print_generated_functions_eliom output ?primary_module ~default_language () ;
-           Format.pp_print_string output "[%%shared\n" ;
-           Format.fprintf output "module Tr = struct\n" ;
-           print_module_body_eliom print_expr_html output key_values ;
-           Format.fprintf output "\nmodule S = struct\n" ;
-           print_module_body_eliom print_expr_string output key_values ;
-           Format.fprintf output "\nend\n" ;
-           Format.fprintf output "end\n" ;
-           Format.pp_print_string output "]\n"
+
+           print_body_eliom output key_values
          )
        else 
          (
@@ -467,13 +477,7 @@ let _ =
              | Some(module_name) -> Format.fprintf output "open %s \n" module_name 
              | None -> failwith "Not possible"
              ) ;
-             
-           Format.fprintf output "module Tr = struct\n"
-           ; print_module_body primary_module print_expr_html output key_values 
-           ; Format.fprintf output "\nmodule S = struct\n" 
-           ; print_module_body primary_module print_expr_string output key_values
-           ; Format.fprintf output "\nend\n" 
-           ; Format.fprintf output "end\n"
+           print_body output key_values primary_module
          )
 
      ; close_in in_chan 


### PR DESCRIPTION
# Now Supporting Non-Eliom Projects

## Summary of Changes

1. **Extended Compatibility**: The i18n functionality now works with non-Eliom projects, while maintaining full support for Eliom projects.
   - Note: There's still a dependency on Tyxml for both Eliom and non-Eliom usage, and the user should define `get_language` and `set_language` functions in the generated-file.

2. **Command Rename**: 
   - Old: `ocsigen-i18n-generator`
   - New: `ocsigen-i18n`

3. **Backward Compatibility**: 
   - The old command `ocsigen-i18n-generator` is now an alias for `ocsigen-i18n --eliom`.
   - This ensures existing projects will continue to work without modification.

4. **New Feature**: Option to generate only the header part of the i18n file.

## Usage Examples

1. For Eliom projects (unchanged behavior):
   ```
   ocsigen-i18n --eliom [other options]
   ```
   or
   ```
   ocsigen-i18n-generator [other options]
   ```

2. For non-Eliom projects:
   ```
   ocsigen-i18n [other options]
   ```

3. To generate only the header:
   ```
   ocsigen-i18n --header [other options]
   ```


Please review these changes and let me know if any further modifications are needed.