### PR TITLE
Modernize Eliom module paths in generated code

### DIFF
--- a/i18n_generate.mll
+++ b/i18n_generate.mll
@@ -118,8 +118,8 @@ let print_type fmt ~variants =
 let print_generated_functions_eliom fmt ?primary_module ~default_language () =
   let server_language_reference =
     match primary_module with
-    | None -> "Eliom_reference.Volatile.eref\n\
-               ~scope:Eliom_common.default_process_scope default_language"
+    | None -> "Eliom.Reference.Volatile.eref\n\
+               ~scope:Eliom.Common.default_process_scope default_language"
     | Some module_name -> module_name ^ "._language_"
   and client_language_reference =
     match primary_module with
@@ -133,15 +133,15 @@ let print_generated_functions_eliom fmt ?primary_module ~default_language () =
   Format.pp_print_string fmt @@
   default_lang ^
   "let%server _language_ = " ^ server_language_reference ^ "\n\
-  let%server get_language () = Eliom_reference.Volatile.get _language_\n\
+  let%server get_language () = Eliom.Reference.Volatile.get _language_\n\
   let%server set_language language = \n\
-  Eliom_reference.Volatile.set _language_ language\n\
+  Eliom.Reference.Volatile.set _language_ language\n\
   \n\
   let%client _language_ = " ^ client_language_reference ^ "\n\
   let%client get_language () = !_language_\n\
   let%client set_language language = _language_ := language\n\
   \n\
-  let%shared txt = Eliom_content.Html.F.txt\n\
+  let%shared txt = Eliom.Content.Html.F.txt\n\
   "
 
 let print_generated_functions fmt ?primary_module ~default_language () =

--- a/test/expected/eliom.expected
+++ b/test/expected/eliom.expected
@@ -12,17 +12,17 @@ with Not_found ->
 raise e 
 let%shared languages = [En;Fr]
 let%shared default_language = En
-let%server _language_ = Eliom_reference.Volatile.eref
-~scope:Eliom_common.default_process_scope default_language
-let%server get_language () = Eliom_reference.Volatile.get _language_
+let%server _language_ = Eliom.Reference.Volatile.eref
+~scope:Eliom.Common.default_process_scope default_language
+let%server get_language () = Eliom.Reference.Volatile.get _language_
 let%server set_language language = 
-Eliom_reference.Volatile.set _language_ language
+Eliom.Reference.Volatile.set _language_ language
 
 let%client _language_ = ref default_language
 let%client get_language () = !_language_
 let%client set_language language = _language_ := language
 
-let%shared txt = Eliom_content.Html.F.txt
+let%shared txt = Eliom.Content.Html.F.txt
 [%%shared
 module Tr = struct
 let foo ?(lang = get_language ()) ()  () =

--- a/test/expected/header_eliom.expected
+++ b/test/expected/header_eliom.expected
@@ -12,14 +12,14 @@ with Not_found ->
 raise e 
 let%shared languages = [En;Fr]
 let%shared default_language = En
-let%server _language_ = Eliom_reference.Volatile.eref
-~scope:Eliom_common.default_process_scope default_language
-let%server get_language () = Eliom_reference.Volatile.get _language_
+let%server _language_ = Eliom.Reference.Volatile.eref
+~scope:Eliom.Common.default_process_scope default_language
+let%server get_language () = Eliom.Reference.Volatile.get _language_
 let%server set_language language = 
-Eliom_reference.Volatile.set _language_ language
+Eliom.Reference.Volatile.set _language_ language
 
 let%client _language_ = ref default_language
 let%client get_language () = !_language_
 let%client set_language language = _language_ := language
 
-let%shared txt = Eliom_content.Html.F.txt
+let%shared txt = Eliom.Content.Html.F.txt


### PR DESCRIPTION
## Summary

- Update generated Eliom code to use the new module path style:
  `Eliom_reference` -> `Eliom.Reference`, `Eliom_common` -> `Eliom.Common`,
  `Eliom_content` -> `Eliom.Content`

This should be merged **after** the new Eliom versions with renamed modules are released.

## Test plan

- [x] `dune build @check` passes
- [x] `dune fmt` produces no diff
- [x] `dune runtest` passes (8 tests)