### PR TITLE
doc: order the manual sidebar with @children_order

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,3 +1,5 @@
+@children_order intro generator ppx templates
+
 {0 Ocsigen-i18n}
 
 Ocsigen-i18n provides internationalisation (i18n) support for OCaml


### PR DESCRIPTION
Part of an effort to make the Ocsigen documentation well-formed on ocaml.org. `doc/index.mld` already is the package home page; add `@children_order intro generator ppx templates` so the manual pages appear in the sidebar in the logical reading order (matching the page body) instead of alphabetically.

Standalone `odoc compile` of `doc/index.mld` succeeds.