### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -6,7 +6,8 @@
 ;; (no odoc-driver). The manual (doc/*.mld) and the API live under ocsigen-i18n/.
 (project ocsigen-i18n)
 (title i18n)
-(pub /ocsigen-i18n)
+(url-prefix /ocsigen-i18n)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (manual-root)
 (landing ocsigen-i18n/index.html)
 (nav


### PR DESCRIPTION
wodoc master now ships a built-in default theme and renames the `pub` stanza to `url-prefix` (see ocsigen/wodoc). This keeps ocsigen-i18n's doc on the shared Ocsigen theme and adopts the new name:

- add `(css /css/style.css /css/ocsigen-odoc.css)` (wodoc's css default changed to a self-contained built-in theme, so this is now needed to keep the shared `/css/` look);
- rename `(pub …)` → `(url-prefix …)`.

The doc CI tracks wodoc master, so no CI change is needed.