### PR TITLE
doc: link Eliom with an odoc reference instead of a hardcoded URL

### DIFF
--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -11,7 +11,7 @@ your program.
 Ocsigen-i18n supports three modes:
 - {b Plain OCaml}: generates simple string functions (default)
 - {b Tyxml}: generates HTML elements using {{:https://github.com/ocsigen/tyxml}Tyxml} ([--tyxml])
-- {b Eliom}: generates client-server code for {{:https://ocsigen.org/eliom/}Eliom} apps ([--eliom])
+- {b Eliom}: generates client-server code for {{!/eliom/page-index}Eliom} apps ([--eliom])
 
 {1 Installation}
 

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -17,3 +17,9 @@
     (link "Template syntax" ocsigen-i18n/templates.html templates))
   (api-section "API"
     (link "Ppx" ocsigen-i18n/Ppx/index.html Ppx)))
+
+;; Sibling Ocsigen projects this doc links to, so wodoc rewrites their
+;; ocaml.org cross-references to relative links into their deployed docs.
+;; (pkg deploy-dir layout wrapper-module)
+(hosted
+  (eliom eliom true Eliom))


### PR DESCRIPTION
Cross-project-links effort. The introduction linked to Eliom with a hardcoded `https://ocsigen.org/eliom/` URL. Use the odoc cross-package reference `{{!/eliom/page-index}}`: odoc resolves it to `/p/eliom` on ocaml.org and wodoc rewrites it to Eliom's deployed docs on ocsigen.org via a new `(hosted (eliom eliom true Eliom))` entry. Compiles with `odoc compile`.