### PR TITLE
ci(doc): fail the build on a dead reference or a leftover wiki image

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -68,6 +68,7 @@ jobs:
           opam exec -- wodoc build --config doc/wodoc
           --menu https://ocsigen.org/doc/menu.html
           --out "$PWD/_doc-site/dev" --label dev
+          --strict-refs
 
       - name: Deploy to gh-pages (replace only dev/, keep the rest)
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
`wodoc build` reports the markup that was meant to become a link or an image and
did not, and `--strict-refs` makes it fatal (ocsigen/wodoc#14, refined in #17,
#18 and #20).

Verified on the rebuild just now: **zero repairable defects**. The 24 references in 1 page it
still lists are references into dependencies this site does not host, which the
check counts apart on one line rather than failing over.

So this changes nothing today and only guards against a regression — the kind that
had the tutorial serving raw wikicréole where its screenshots should be, and 34
dead intra-manual links, unnoticed.
